### PR TITLE
Bump peer ID to 220

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -82,8 +82,8 @@ chmod +x /usr/bin/7z
 # tweaks
 ####
 
-# change peerid to appear to be 2.1.1 stable - note this MAY not work for all private trackers at present
-sed -i -e "s~peer_id = substitute_chr(peer_id, 6, release_chr)~peer_id = \'-DE211s-\'\n        release_chr = \'s\'~g" /usr/lib/python3*/site-packages/deluge/core/core.py
+# change peerid to appear to be 2.2.0 stable - note this MAY not work for all private trackers at present
+sed -i -e "s~peer_id = substitute_chr(peer_id, 6, release_chr)~peer_id = \'-DE220s-\'\n        release_chr = \'s\'~g" /usr/lib/python3*/site-packages/deluge/core/core.py
 
 # container perms
 ####


### PR DESCRIPTION
Same change as this PR in the VPN repo: https://github.com/binhex/arch-delugevpn/pull/426

Currently broken for some private trackers due to the mismatch.